### PR TITLE
Add AppMenu to finish args

### DIFF
--- a/org.zulip.Zulip.yaml
+++ b/org.zulip.Zulip.yaml
@@ -20,6 +20,7 @@ finish-args:
   - --filesystem=xdg-pictures
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=com.canonical.AppMenu.Registrar
 build-options:
   append-path: /usr/lib/sdk/node16/bin
   cflags: -O2 -g


### PR DESCRIPTION
This pull request adds a new entry to the finish args to enable Global Menu widgets from kde and xfce to recognize the Zulip's global menu and integrate them.

Image 1: Example without the new finish args
![Screenshot_20220530_155511](https://user-images.githubusercontent.com/51462138/171047746-81aaed4e-3876-49f5-a9d0-6d3588c1fe75.png)

Image 2: Example with the new finish args
![Screenshot_20220530_155449](https://user-images.githubusercontent.com/51462138/171047758-b1fb7975-9d7b-4fc3-82f6-cb6f72309559.png)

