### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/org.zulip.Zulip.yaml
+++ b/org.zulip.Zulip.yaml
@@ -20,7 +20,6 @@ finish-args:
   - --filesystem=xdg-pictures
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.*
   - --talk-name=com.canonical.AppMenu.Registrar
 build-options:
   append-path: /usr/lib/sdk/node18/bin


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 25.8.1
https://github.com/zulip/zulip-desktop/blob/b520e12492834eaa4f001247bad647d6bf5c8cf9/package.json#L162