### PR TITLE
Remove org.freedesktop.Notifications bus access

### DIFF
--- a/org.zulip.Zulip.yaml
+++ b/org.zulip.Zulip.yaml
@@ -18,7 +18,6 @@ finish-args:
   - --filesystem=xdg-download
   - --filesystem=xdg-documents
   - --filesystem=xdg-pictures
-  - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar
 build-options:


### PR DESCRIPTION
The electron baseapp has libnotify 0.8 which uses the portal for notifications, so this is no longer required

See https://gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25